### PR TITLE
Use `assert` instead of `print`

### DIFF
--- a/06_comprehension.py
+++ b/06_comprehension.py
@@ -15,5 +15,5 @@ odds = [
   if number not in evens
 ]
 
-print(evens) # [2, 4, 6, 8, 10]
-print(odds) # [1, 3, 5, 7, 9]
+assert evens == [2, 4, 6, 8, 10]
+assert odds == [1, 3, 5, 7, 9]


### PR DESCRIPTION
Using `assert` instead of `print` helps to verify the output without running the program. 