### PR TITLE
Use `assert` instead of `print`

### DIFF
--- a/11_generators.py
+++ b/11_generators.py
@@ -4,6 +4,6 @@ def next_num(i):
 
 iterator = next_num(10)
 
-print(next(iterator)) # 10
-print(next(iterator)) # 11
-print(next(iterator)) # 12
+assert next(iterator) == 10
+assert next(iterator) == 11
+assert next(iterator) == 12


### PR DESCRIPTION
Using `assert` instead of `print` helps to verify the output without running the program. 