### PR TITLE
Use `assert` instead of `print`

### DIFF
--- a/14_class_func.py
+++ b/14_class_func.py
@@ -12,4 +12,4 @@ class Adder():
 a = Adder()
 a.inject(2)
 a.inject(5)
-print(a())  # 7
+assert a() == 7


### PR DESCRIPTION
Using `assert` instead of `print` helps to verify the output without running the program. 